### PR TITLE
disable errors when escaping \8 and \9

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -14,7 +14,6 @@ export const enum Errors {
   MissingExponent,
   InvalidBigInt,
   IDStartAfterNumber,
-  // InvalidEightAndNine, // disabled
   UnterminatedString,
   UnterminatedTemplate,
   UnterminatedComment,

--- a/src/lexer/string.ts
+++ b/src/lexer/string.ts
@@ -8,7 +8,6 @@ import { toHex, advanceChar, fromCodePoint, CharTypes, CharFlags } from './';
 export const enum Escape {
   Empty = -1,
   StrictOctal = -2,
-  // EightOrNine = -3, // disabled
   InvalidHex = -4,
   OutOfRange = -5
 }


### PR DESCRIPTION
Related to surfly/it/issues/351

Issue: when `"\8"` or `"\9"` strings are present in parsed JS code, meriyah throws error, while such strings are parsed by browsers without any errors. Error thrown by meriyah breaks our JS processing, and results in uproxified code on client sites.

Unit test will be added in cobro with meriyah version update