### PR TITLE
Fix usage of `async` and `import` in comma expression

### DIFF
--- a/dist/meriyah.umd.js
+++ b/dist/meriyah.umd.js
@@ -5119,10 +5119,11 @@
           parser.assignable = 1;
       }
       expr = parseMemberOrUpdateExpression(parser, context, expr, 0, 0, start, line, column);
-      if (parser.token === 18)
-          expr = parseSequenceExpression(parser, context, 0, start, line, column, expr);
       expr = parseAssignmentExpression(parser, context, 0, 0, start, line, column, expr);
       parser.assignable = 1;
+      if (parser.token === 18) {
+          expr = parseSequenceExpression(parser, context, 0, start, line, column, expr);
+      }
       return parseExpressionStatement(parser, context, expr, start, line, column);
   }
   function parseDirective(parser, context, expression, token, start, line, column) {
@@ -5782,6 +5783,9 @@
       }), start, line, column);
       expr = parseMemberOrUpdateExpression(parser, context, expr, 0, 0, start, line, column);
       expr = parseAssignmentExpression(parser, context, 0, 0, start, line, column, expr);
+      if (parser.token === 18) {
+          expr = parseSequenceExpression(parser, context, 0, start, line, column, expr);
+      }
       return parseExpressionStatement(parser, context, expr, start, line, column);
   }
   function parseImportCallDeclaration(parser, context, start, line, column) {
@@ -6125,6 +6129,7 @@
               report(parser, 49);
           return parseArrowFromIdentifier(parser, context, parser.tokenValue, expr, inNew, canAssign, 0, start, line, column);
       }
+      parser.assignable = 1;
       return expr;
   }
   function parseYieldExpression(parser, context, inGroup, canAssign, start, line, column) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1118,15 +1118,6 @@ export function parseAsyncArrowOrAsyncFunctionDeclaration(
    */
 
   expr = parseMemberOrUpdateExpression(parser, context, expr, 0, 0, start, line, column);
-  /** Sequence expression
-   *
-   * Note: The comma operator leads to a sequence expression which is not equivalent
-   * to the ES Expression, but it's part of the ESTree specs:
-   *
-   * https://github.com/estree/estree/blob/master/es5.md#sequenceexpression
-   *
-   */
-  if (parser.token === Token.Comma) expr = parseSequenceExpression(parser, context, 0, start, line, column, expr);
 
   /** AssignmentExpression :
    *
@@ -1137,6 +1128,16 @@ export function parseAsyncArrowOrAsyncFunctionDeclaration(
   expr = parseAssignmentExpression(parser, context, 0, 0, start, line, column, expr as ESTree.ArgumentExpression);
 
   parser.assignable = AssignmentKind.Assignable;
+
+  /** Sequence expression
+   *
+   * Note: The comma operator leads to a sequence expression which is not equivalent
+   * to the ES Expression, but it's part of the ESTree specs:
+   *
+   * https://github.com/estree/estree/blob/master/es5.md#sequenceexpression
+   *
+   */
+  if (parser.token === Token.Comma) expr = parseSequenceExpression(parser, context, 0, start, line, column, expr);
 
   /**
    * ExpressionStatement[Yield, Await]:

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3671,6 +3671,8 @@ export function parseAsyncExpression(
     if (inNew) report(parser, Errors.InvalidAsyncArrow);
     return parseArrowFromIdentifier(parser, context, parser.tokenValue, expr, inNew, canAssign, 0, start, line, column);
   }
+
+  parser.assignable = AssignmentKind.Assignable;
   return expr;
 }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1137,7 +1137,9 @@ export function parseAsyncArrowOrAsyncFunctionDeclaration(
    * https://github.com/estree/estree/blob/master/es5.md#sequenceexpression
    *
    */
-  if (parser.token === Token.Comma) expr = parseSequenceExpression(parser, context, 0, start, line, column, expr);
+  if (parser.token === Token.Comma) {
+    expr = parseSequenceExpression(parser, context, 0, start, line, column, expr);
+  }
 
   /**
    * ExpressionStatement[Yield, Await]:
@@ -2765,6 +2767,10 @@ export function parseImportMetaDeclaration(
    */
 
   expr = parseAssignmentExpression(parser, context, 0, 0, start, line, column, expr as ESTree.Expression);
+
+  if (parser.token === Token.Comma) {
+    expr = parseSequenceExpression(parser, context, 0, start, line, column, expr);
+  }
 
   /**
    * ExpressionStatement[Yield, Await]:

--- a/test/parser/declarations/functions.ts
+++ b/test/parser/declarations/functions.ts
@@ -398,6 +398,7 @@ describe('Declarations - Function', () => {
     'function f() { const await = 10; }',
     'function f(a = async function (x) { await x; }) { a(); } f();',
     'function f() {async = 1, a = 2;}',
+    'function f() {a = 1, async = 2;}',
     'function f() {var async = 1; return async;}',
     'function f() {let async = 1; return async;}',
     'function f() {const async = 1; return async;}',

--- a/test/parser/declarations/functions.ts
+++ b/test/parser/declarations/functions.ts
@@ -397,6 +397,7 @@ describe('Declarations - Function', () => {
     'function f() { function await() { } }',
     'function f() { const await = 10; }',
     'function f(a = async function (x) { await x; }) { a(); } f();',
+    'function f() {async = 1, a = 2;}',
     'function f() {var async = 1; return async;}',
     'function f() {let async = 1; return async;}',
     'function f() {const async = 1; return async;}',

--- a/test/parser/miscellaneous/pass.ts
+++ b/test/parser/miscellaneous/pass.ts
@@ -2835,6 +2835,7 @@ after = err;
     'class X { await() {} }',
     'let async = await;',
     'async = 1, b = 2;',
+    'b = 2, async = 1;',
     'x = { await: false }',
     'yield[100]',
     `async

--- a/test/parser/miscellaneous/pass.ts
+++ b/test/parser/miscellaneous/pass.ts
@@ -2834,6 +2834,7 @@ after = err;
     'x = await(y);',
     'class X { await() {} }',
     'let async = await;',
+    'async = 1, b = 2;',
     'x = { await: false }',
     'yield[100]',
     `async

--- a/test/parser/next/import-meta.ts
+++ b/test/parser/next/import-meta.ts
@@ -100,6 +100,10 @@ describe('Next - Import Meta', () => {
     '(a?.import("string")?.import.meta??(a))',
     'import.meta?.(a?.import("string")?.import.meta??(a))',
     'var a = import.meta;',
+    'import.meta, 1;',
+    '1, import.meta;',
+    'import.meta, a = 1;',
+    'a = 1, import.meta;',
     'import.meta;'
   ]) {
     it(`${arg}`, () => {


### PR DESCRIPTION
Fixes usage of `async` and `import` in comma expressions, like:
```js
async = 1, b = 2;
b = 2, async = 1;
import.meta, 1;
```

Copy of https://github.com/meriyah/meriyah/pull/254
