### PR TITLE
Handle correctly octal or hex values located in template strings

### DIFF
--- a/dist/meriyah.umd.js
+++ b/dist/meriyah.umd.js
@@ -6314,7 +6314,7 @@
               case 67108877: {
                   nextToken(parser, (context | 1073741824 | 8192) ^ 8192);
                   parser.assignable = 1;
-                  const property = parsePropertyOrPrivatePropertyName(parser, context);
+                  const property = parsePropertyOrPrivatePropertyName(parser, context | 65536);
                   expr = finishNode(parser, context, start, line, column, {
                       type: 'MemberExpression',
                       object: expr,

--- a/dist/meriyah.umd.js
+++ b/dist/meriyah.umd.js
@@ -6534,7 +6534,7 @@
           case 67174411:
               const leadingComment = collectLeadingComments(parser);
               parser.leadingComments && parser.leadingComments.pop();
-              const exprNode = parseParenthesizedExpression(parser, context, canAssign, 1, 0, start, line, column);
+              const exprNode = parseParenthesizedExpression(parser, context | 65536, canAssign, 1, 0, start, line, column);
               if (exprNode.leadingComment && leadingComment) {
                   exprNode.leadingComments.concat(leadingComment);
               }
@@ -6711,7 +6711,7 @@
       nextToken(parser, context | 32768);
       const args = [];
       if (parser.token === 16) {
-          nextToken(parser, context);
+          nextToken(parser, context | 65536);
           return args;
       }
       while (parser.token !== 16) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -4043,7 +4043,7 @@ export function parseMemberOrUpdateExpression(
 
         parser.assignable = AssignmentKind.Assignable;
 
-        const property = parsePropertyOrPrivatePropertyName(parser, context);
+        const property = parsePropertyOrPrivatePropertyName(parser, context | Context.TaggedTemplate);
 
         expr = finishNode(parser, context, start, line, column, {
           type: 'MemberExpression',

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -4407,7 +4407,7 @@ export function parsePrimaryExpression(
       parser.leadingComments && parser.leadingComments.pop();
       const exprNode = parseParenthesizedExpression(
         parser,
-        context,
+        context | Context.TaggedTemplate,
         canAssign,
         BindingKind.ArgumentList,
         Origin.None,
@@ -4802,7 +4802,7 @@ export function parseArguments(
   const args: (ESTree.Expression | ESTree.SpreadElement)[] = [];
 
   if (parser.token === Token.RightParen) {
-    nextToken(parser, context);
+    nextToken(parser, context | Context.TaggedTemplate);
     return args;
   }
 

--- a/test/parser/expressions/template.ts
+++ b/test/parser/expressions/template.ts
@@ -338,7 +338,14 @@ describe('Expressions - Template', () => {
     'test`\\18`;',
     '(`\n`)',
     '(`\r`)',
-    'new nestedNewOperatorFunction`1``2``3``array`'
+    'new nestedNewOperatorFunction`1``2``3``array`',
+    "tag()`'\\00a0'`;",
+    "(tag = () => {})`'\\00a0'`",
+    "(() => {})`'\\00a0'`",
+    "(function tag() { return () => {}; })()`'\\00a0'`",
+    "(function() { return () => {}; })()`'\\00a0'`",
+    "(function tag() {})`'\\00a0'`",
+    "(function() {})`'\\00a0'`"
   ]) {
     it(`${arg}`, () => {
       t.doesNotThrow(() => {
@@ -4032,6 +4039,92 @@ describe('Expressions - Template', () => {
             column: 0
           }
         }
+      }
+    ],
+    [
+      "tag()`'\\00a0'`;",
+      Context.None,
+      {
+        body: [
+          {
+            expression: {
+              quasi: {
+                expressions: [],
+                quasis: [
+                  {
+                    tail: true,
+                    type: 'TemplateElement',
+                    value: {
+                      cooked: undefined,
+                      raw: "'\\00a0'"
+                    }
+                  }
+                ],
+                type: 'TemplateLiteral'
+              },
+              tag: {
+                arguments: [],
+                callee: {
+                  name: 'tag',
+                  type: 'Identifier'
+                },
+                type: 'CallExpression'
+              },
+              type: 'TaggedTemplateExpression'
+            },
+            type: 'ExpressionStatement'
+          }
+        ],
+        sourceType: 'script',
+        type: 'Program'
+      }
+    ],
+    [
+      "(tag = () => {})`'\\00a0'`",
+      Context.None,
+      {
+        body: [
+          {
+            expression: {
+              quasi: {
+                expressions: [],
+                quasis: [
+                  {
+                    tail: true,
+                    type: 'TemplateElement',
+                    value: {
+                      cooked: undefined,
+                      raw: "'\\00a0'"
+                    }
+                  }
+                ],
+                type: 'TemplateLiteral'
+              },
+              tag: {
+                left: {
+                  name: 'tag',
+                  type: 'Identifier'
+                },
+                operator: '=',
+                right: {
+                  async: false,
+                  body: {
+                    body: [],
+                    type: 'BlockStatement'
+                  },
+                  expression: false,
+                  params: [],
+                  type: 'ArrowFunctionExpression'
+                },
+                type: 'AssignmentExpression'
+              },
+              type: 'TaggedTemplateExpression'
+            },
+            type: 'ExpressionStatement'
+          }
+        ],
+        sourceType: 'script',
+        type: 'Program'
       }
     ]
   ]);

--- a/test/parser/expressions/template.ts
+++ b/test/parser/expressions/template.ts
@@ -345,7 +345,8 @@ describe('Expressions - Template', () => {
     "(function tag() { return () => {}; })()`'\\00a0'`",
     "(function() { return () => {}; })()`'\\00a0'`",
     "(function tag() {})`'\\00a0'`",
-    "(function() {})`'\\00a0'`"
+    "(function() {})`'\\00a0'`",
+    'String.raw`{\rtf1adeflang1025ansiansicpg1252\\uc1`;'
   ]) {
     it(`${arg}`, () => {
       t.doesNotThrow(() => {
@@ -4117,6 +4118,48 @@ describe('Expressions - Template', () => {
                   type: 'ArrowFunctionExpression'
                 },
                 type: 'AssignmentExpression'
+              },
+              type: 'TaggedTemplateExpression'
+            },
+            type: 'ExpressionStatement'
+          }
+        ],
+        sourceType: 'script',
+        type: 'Program'
+      }
+    ],
+    [
+      'String.raw`{\rtf1adeflang1025ansiansicpg1252\\uc1`;',
+      Context.None,
+      {
+        body: [
+          {
+            expression: {
+              quasi: {
+                expressions: [],
+                quasis: [
+                  {
+                    tail: true,
+                    type: 'TemplateElement',
+                    value: {
+                      cooked: undefined,
+                      raw: '{\rtf1adeflang1025ansiansicpg1252\\uc1'
+                    }
+                  }
+                ],
+                type: 'TemplateLiteral'
+              },
+              tag: {
+                computed: false,
+                object: {
+                  name: 'String',
+                  type: 'Identifier'
+                },
+                property: {
+                  name: 'raw',
+                  type: 'Identifier'
+                },
+                type: 'MemberExpression'
               },
               type: 'TaggedTemplateExpression'
             },


### PR DESCRIPTION
The PR fixes these two issues:
https://github.com/surfly/it/issues/4752
https://github.com/surfly/it/issues/4815

In general the PR fixes these two corner cases with template strings:
1. tag()\`template string with octal or hex value\`
2. String.raw\`template string with octal or hex value\`
